### PR TITLE
more windows fixes

### DIFF
--- a/windows.lisp
+++ b/windows.lisp
@@ -22,10 +22,10 @@
 (defconstant generic-read 2147483648)
 (defconstant generic-write 1073741824)
 (defconstant invalid-file-size 4294967295)
-;; ccl doesn't like constant pointers in middle of address space, so
-;; store INVALID-HANDLE-VALUE as an integer
-(defconstant invalid-handle-value 4294967295)
-
+(defconstant invalid-handle-value
+  (if (boundp 'invalid-handle-value)
+      invalid-handle-value
+      (cffi:make-pointer 4294967295)))
 (defconstant open-always 4)
 (defconstant open-existing 3)
 (defconstant page-execute-read 32)
@@ -122,8 +122,7 @@
 (defun %mmap (path size offset open-access open-disposition open-flags protection map-access)
   (declare (type fixnum open-access open-disposition open-flags protection map-access offset))
   (declare (optimize speed))
-  (let* ((invalid-fd (cffi:make-pointer invalid-handle-value))
-         (fd invalid-fd))
+  (let ((fd invalid-handle-value))
     (declare (type (or null (unsigned-byte 64)) size))
     (declare (type cffi:foreign-pointer fd))
     (etypecase path
@@ -138,7 +137,7 @@
                                open-disposition
                                open-flags
                                (cffi:null-pointer))))
-       (check-windows (not (cffi:pointer-eq fd invalid-fd)))
+       (check-windows (not (cffi:pointer-eq fd invalid-handle-value)))
        (unless size
          (cffi:with-foreign-object (tmp 'large-integer)
            (let ((ret (get-file-size-ex fd tmp)))

--- a/windows.lisp
+++ b/windows.lisp
@@ -25,7 +25,9 @@
 (defconstant invalid-handle-value
   (if (boundp 'invalid-handle-value)
       invalid-handle-value
-      (cffi:make-pointer 4294967295)))
+      (if (= 8 (cffi:foreign-type-size :pointer))
+          (cffi:make-pointer (ldb (byte 64 0) -1))
+          (cffi:make-pointer (ldb (byte 32 0) -1)))))
 (defconstant open-always 4)
 (defconstant open-existing 3)
 (defconstant page-execute-read 32)

--- a/windows.lisp
+++ b/windows.lisp
@@ -36,7 +36,7 @@
 
 (cffi:defctype wchar_t :uint16)
 (cffi:defctype handle :pointer)
-(cffi:defctype lpsecurity-attributes :uint64 #+x86 :uint32)
+(cffi:defctype lpsecurity-attributes :pointer)
 (cffi:defctype dword :uint32)
 (cffi:defctype large-integer :uint64)
 (cffi:defctype size_t #+x86-64 :uint64 #+x86 :uint32)
@@ -134,7 +134,7 @@
                                (logior file-share-delete
                                        file-share-read
                                        file-share-write)
-                               0
+                               (cffi:null-pointer)
                                open-disposition
                                open-flags
                                (cffi:null-pointer))))
@@ -147,7 +147,7 @@
       (null))
     (let* ((end (+ (the (unsigned-byte 64) size) offset))
            (handle (create-file-mapping fd
-                                        0
+                                        (cffi:null-pointer)
                                         protection
                                         (ldb (byte 32 32) end)
                                         (ldb (byte 32 0) end)


### PR DESCRIPTION
fix bad type definition due to missing #-x86 (changes arg type for a few ffi functions, but they aren't exported, so probably OK?

undo previous ccl-specific change since correct value for INVALID-HANDLE-VALUE seems to be one ccl would accept

use correct value for INVALIE-HANDLE-VALUE