### PR TITLE
Fix mmap: accept null path.

### DIFF
--- a/generic.lisp
+++ b/generic.lisp
@@ -24,7 +24,8 @@
 (defun translate-path (path)
   (etypecase path
     (string path)
-    (pathname (uiop:native-namestring path))))
+    (pathname (uiop:native-namestring path))
+    (null)))
 
 #-(or unix windows)
 (defun mmap (path &key open protection mmap)

--- a/posix.lisp
+++ b/posix.lisp
@@ -130,9 +130,7 @@
         (values addr fd size)))))
 
 (defun mmap (path &key (open '(:read)) (protection '(:read)) (mmap '(:private)) size (offset 0))
-  (%mmap (etypecase path
-           (string path)
-           (pathname (uiop:native-namestring path)))
+  (%mmap (translate-path path)
          size offset
          (cffi:foreign-bitfield-value 'open-flag open)
          (cffi:foreign-bitfield-value 'protection-flag protection)


### PR DESCRIPTION
Contrary to what the documentation of `mmap` indicates, passing a null path argument signals an error instead of mapping an anonymous file.