### PR TITLE
mmap: Add file descriptor as parameter to PATH

### DIFF
--- a/documentation.lisp
+++ b/documentation.lisp
@@ -147,9 +147,6 @@ same goes for calling MUNMAP with values not directly returned by MMAP,
 calling it with changed values returned by MMAP, or attempting to
 dereference the PTR after a call to MUNMAP.
 
-If an open file descriptor was passed to MMAP, then MUNMAP will not attempt
-to close the file.
-
 This function returns nothing useful.
 
 This function may signal an MMAP-ERROR in case the operating system notices
@@ -224,6 +221,9 @@ This is a convenience macro that calls MMAP with the given arguments,
 binds the results to the variables ADDR, FD, and SIZE, and automatically
 ensures that MUNMAP is called with the correct values when the body is
 exited.
+
+If the flag DONT-CLOSE is set, WITH-MMAP will not free the file associated
+with the given path.
 
 It is safe to change the ADDR, FD, and SIZE bindings, though probably not
 very good style to do so. It is NOT safe to save the ADDR and SIZE values

--- a/documentation.lisp
+++ b/documentation.lisp
@@ -35,14 +35,15 @@ See MMAP-ERROR")
   (function mmap
     "Map the given path or number of bytes into the address space.
 
-PATH can be either a pathname designator, or NIL. If it is NIL, an anonymous
-file is mapped and the MMAP flag list must include the flag :ANONYMOUS. If
-it is a path or an open POSIX file descriptor, then the contents of the
-given file on the file system are mapped into the address space. The file
-contents can then be read, written, or executed depending on the given flags
-as if normal memory was accessed. If the file is NIL or its size cannot be
-automatically determined, you must pass a valid SIZE. You may optionally
-pass an OFFSET (in bytes) into the file from which the mapping begins.
+PATH can be either a pathname designator, FD, or NIL. If it is NIL, an
+anonymous file is mapped and the MMAP flag list must include the flag
+:ANONYMOUS. If it is a path or an open POSIX file descriptor, then the
+contents of the given file on the file system are mapped into the
+address space. The file contents can then be read, written, or
+executed depending on the given flags as if normal memory was
+accessed. If the file is NIL or its size cannot be automatically
+determined, you must pass a valid SIZE. You may optionally pass an
+OFFSET (in bytes) into the file from which the mapping begins.
 
 If the map attempt fails, an error of type MMAP-ERROR is signalled.
 If the call succeeds, three values are returned:
@@ -51,7 +52,7 @@ If the call succeeds, three values are returned:
            memory where the file contents have been mapped. The contents
            should be placed in increasing address order, unless the flag
            :GROWS-DOWN is active.
-  FD   --- A fresh opaque file descriptor. You should not touch this.
+  FD   --- An opaque file descriptor. You should not touch this.
   SIZE --- The size of the region of memory that has been mapped in bytes.
 
 All three values need to be passed on to MUNMAP completely unchanged. Any
@@ -149,6 +150,10 @@ dereference the PTR after a call to MUNMAP.
 
 This function returns nothing useful.
 
+On POSIX systems you may pass NIL for the FD argument, in which case
+the file descriptor is not closed. It is then your responsibility to
+close it appropriately at a later point.
+
 This function may signal an MMAP-ERROR in case the operating system notices
 a problem.
 
@@ -222,8 +227,10 @@ binds the results to the variables ADDR, FD, and SIZE, and automatically
 ensures that MUNMAP is called with the correct values when the body is
 exited.
 
-If the flag DONT-CLOSE is set, WITH-MMAP will not free the file associated
-with the given path.
+If the flag DONT-CLOSE is set, WITH-MMAP will not free the file
+descriptor on unwind. This is useful primarily if you pass in an FD
+for the path yourself and are either not responsible for closing it,
+or would like to continue using it for other purposes.
 
 It is safe to change the ADDR, FD, and SIZE bindings, though probably not
 very good style to do so. It is NOT safe to save the ADDR and SIZE values

--- a/documentation.lisp
+++ b/documentation.lisp
@@ -36,13 +36,13 @@ See MMAP-ERROR")
     "Map the given path or number of bytes into the address space.
 
 PATH can be either a pathname designator, or NIL. If it is NIL, an anonymous
-file is mapped and the MMAP flag list must include the flag :ANONYMOUS.
-If it is a path, then the contents of the given file on the file system are
-mapped into the address space. The file contents can then be read, written,
-or executed depending on the given flags as if normal memory was accessed.
-If the file is NIL or its size cannot be automatically determined, you must
-pass a valid SIZE. You may optionally pass an OFFSET (in bytes) into the
-file from which the mapping begins.
+file is mapped and the MMAP flag list must include the flag :ANONYMOUS. If
+it is a path or an open POSIX file descriptor, then the contents of the
+given file on the file system are mapped into the address space. The file
+contents can then be read, written, or executed depending on the given flags
+as if normal memory was accessed. If the file is NIL or its size cannot be
+automatically determined, you must pass a valid SIZE. You may optionally
+pass an OFFSET (in bytes) into the file from which the mapping begins.
 
 If the map attempt fails, an error of type MMAP-ERROR is signalled.
 If the call succeeds, three values are returned:
@@ -51,7 +51,7 @@ If the call succeeds, three values are returned:
            memory where the file contents have been mapped. The contents
            should be placed in increasing address order, unless the flag
            :GROWS-DOWN is active.
-  FD   --- An opaque file descriptor. You should not touch this.
+  FD   --- A fresh opaque file descriptor. You should not touch this.
   SIZE --- The size of the region of memory that has been mapped in bytes.
 
 All three values need to be passed on to MUNMAP completely unchanged. Any
@@ -147,6 +147,9 @@ same goes for calling MUNMAP with values not directly returned by MMAP,
 calling it with changed values returned by MMAP, or attempting to
 dereference the PTR after a call to MUNMAP.
 
+If an open file descriptor was passed to MMAP, then MUNMAP will not attempt
+to close the file.
+
 This function returns nothing useful.
 
 This function may signal an MMAP-ERROR in case the operating system notices
@@ -168,7 +171,7 @@ to MMAP.
 
 The following flags are supported:
 
- :SYNC          --- [EVERY] Writing is synchronous. A call to this function 
+ :SYNC          --- [EVERY] Writing is synchronous. A call to this function
                             will not return until the data is flushed to
                             disk.
  :ASYNC         --- [EVERY] Writing is asynchronous and a call will return

--- a/generic.lisp
+++ b/generic.lisp
@@ -46,10 +46,11 @@
   (error "Platform not supported."))
 
 (defmacro with-mmap ((addr fd size path &rest args &key dont-close &allow-other-keys) &body body)
-  (remf args :dont-close)
   (let ((addrg (gensym "ADDR"))
         (fdg (gensym "FD"))
-        (sizeg (gensym "SIZE")))
+        (sizeg (gensym "SIZE"))
+        (args (copy-list args)))
+    (remf args :dont-close)
     `(multiple-value-bind (,addrg ,fdg ,sizeg) (mmap ,path ,@args)
        (unwind-protect
             (let ((,addr ,addrg)

--- a/generic.lisp
+++ b/generic.lisp
@@ -24,7 +24,7 @@
 (defun translate-path (path)
   (etypecase path
     #+unix
-    ((and fixnum unsigned-byte) path)
+    ((unsigned-byte #+64-bit 64 #-64-bit 32) path)
     (string path)
     (pathname (uiop:native-namestring path))
     (null)))

--- a/generic.lisp
+++ b/generic.lisp
@@ -45,7 +45,8 @@
 (defun mprotect (addr size protection)
   (error "Platform not supported."))
 
-(defmacro with-mmap ((addr fd size path &rest args) &body body)
+(defmacro with-mmap ((addr fd size path &rest args &key dont-close &allow-other-keys) &body body)
+  (remf args :dont-close)
   (let ((addrg (gensym "ADDR"))
         (fdg (gensym "FD"))
         (sizeg (gensym "SIZE")))
@@ -56,4 +57,4 @@
                   (,size ,sizeg))
               (declare (ignorable ,fd ,size))
               ,@body)
-         (munmap ,addrg ,fdg ,sizeg)))))
+         (munmap ,addrg ,(unless dont-close fdg) ,sizeg)))))

--- a/generic.lisp
+++ b/generic.lisp
@@ -23,6 +23,8 @@
 
 (defun translate-path (path)
   (etypecase path
+    #+unix
+    ((and fixnum unsigned-byte) path)
     (string path)
     (pathname (uiop:native-namestring path))
     (null)))

--- a/posix.lisp
+++ b/posix.lisp
@@ -108,7 +108,6 @@
   (declare (type fixnum open protection mmap))
   (declare (optimize speed))
   (let ((fd -1)
-        fresh-fd
         (error-handler (constantly nil)))
     (etypecase path
       ((and fixnum unsigned-byte)
@@ -118,7 +117,6 @@
         (check-type size unsigned-byte))
       (string
        (setf fd (u-open path open)
-             fresh-fd fd
              error-handler (lambda (e)
                             (declare (ignore e))
                             (check-posix (= 0 (u-close fd)))))
@@ -135,7 +133,7 @@
                           fd
                           offset)))
         (check-posix (/= (1- (ash 1 64)) (cffi:pointer-address addr)))
-        (values addr fresh-fd size)))))
+        (values addr fd size)))))
 
 (defun mmap (path &key (open '(:read)) (protection '(:read)) (mmap '(:private)) size (offset 0))
   (%mmap (translate-path path)

--- a/test.lisp
+++ b/test.lisp
@@ -23,3 +23,17 @@
      (mmap:with-mmap (addr fd size *this*)
        (setf mmapped (cffi:foreign-string-to-lisp addr :count size :encoding :utf-8))))
     (is string= read mmapped)))
+
+#+unix
+(define-test read-fd
+  :parent mmap
+  (let (fd mmapped read)
+    (finish
+      (setf read (alexandria:read-file-into-string *this* :external-format :utf-8)))
+    (of-type unsigned-byte
+             (setf fd (mmap::u-open (uiop:native-namestring *this*) '(:read))))
+    (finish
+      (mmap:with-mmap (addr fd* size fd :size (length read))
+        (setf mmapped (cffi:foreign-string-to-lisp addr :count size :encoding :utf-8))))
+    (is = 0 (mmap::u-close fd))
+    (is string= read mmapped)))

--- a/test.lisp
+++ b/test.lisp
@@ -33,7 +33,7 @@
     (of-type unsigned-byte
              (setf fd (mmap::u-open (uiop:native-namestring *this*) '(:read))))
     (finish
-      (mmap:with-mmap (addr fd* size fd :size (length read))
+      (mmap:with-mmap (addr fd* size fd :size (length read) :dont-close t)
         (setf mmapped (cffi:foreign-string-to-lisp addr :count size :encoding :utf-8))))
     (is = 0 (mmap::u-close fd))
     (is string= read mmapped)))


### PR DESCRIPTION
A programmer may wish to create a shared memory object via the POSIX shm API, mmap a descriptor of an anonyous file through some local address socket, or otherwise mmap a file descriptor whose pathname cannot or should not be determined.

This commit enables file descriptors to be passed through the PATH parameter of MMAP on Unix systems. Since it did not open the fd, MUNMAP does not close the fd either.

Although fstat *could* be used to automatically determine the size of the file descriptor, this pass goes for the simpler option and requires the SIZE parameter.

Example use-case:

```lisp
(defvar fd (shm:open-temporary-shm "/blablabla"))
(shm:ftruncate fd 10)

(mmap:with-mmap (addr %fd size fd :size 10 :open '(:read :write))
  (dotimes (i size) 
    (setf (cffi:mem-ref addr :char i) (* i 10)))
  (dotimes (i size)
    (print (cffi:mem-ref addr :char i))))

(shm:close fd)
```